### PR TITLE
운동 기록 상세 조회 기능 추가

### DIFF
--- a/HealthBoard/src/main/java/org/health/domain/BoardLikeDTO.java
+++ b/HealthBoard/src/main/java/org/health/domain/BoardLikeDTO.java
@@ -1,0 +1,23 @@
+package org.health.domain;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class BoardLikeDTO {
+    private int board_id;
+    private int user_id;
+    private String nickname;
+    private String exercise_type;
+    private int exercise_time;
+    private String memo;
+    private LocalDate create_at;
+    private boolean visible;
+    private int like_count;
+    private boolean like_status;
+}

--- a/HealthBoard/src/main/java/org/health/repository/BoardRepository.java
+++ b/HealthBoard/src/main/java/org/health/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package org.health.repository;
 
 import org.health.domain.BoardDTO;
+import org.health.domain.BoardLikeDTO;
 
 import java.util.List;
 
@@ -10,5 +11,5 @@ public interface BoardRepository {
     int changeVisible(BoardDTO board);
     List<BoardDTO> findByUser_id(int user_id);
     List<BoardDTO> findAll();
-    BoardDTO findById(int id);
+    BoardLikeDTO findById(int board_id, int user_id);
 }

--- a/HealthBoard/src/test/java/BoardLikeFindTest.java
+++ b/HealthBoard/src/test/java/BoardLikeFindTest.java
@@ -1,0 +1,24 @@
+import org.health.domain.BoardLikeDTO;
+import org.health.repository.BoardRepository;
+import org.health.repository.BoardRepositoryImpl;
+
+public class BoardLikeFindTest {
+
+    public static void main(String[] args) {
+        // given
+        BoardRepository instance = BoardRepositoryImpl.getInstance();
+        int board_id = 1;
+        int user_id = 1;
+
+        // when
+        BoardLikeDTO boardLikeDTO = instance.findById(board_id, user_id);
+
+        // then
+        if (boardLikeDTO.getLike_count() != 2) {
+            System.out.println("assert failure");
+        } else {
+            System.out.println("assert success");
+        }
+        System.out.println(boardLikeDTO);
+    }
+}


### PR DESCRIPTION
## 이슈
운동 기록 상세 조회 기능

## 내용
운동 기록 상세 조회 기능을 추가했습니다.

## 기타 특이사항
- 상세 조회용 `BoardLikeDTO`를 새로 만들어서, `BoardRepository` 인터페이스 명세도 같이 수정되었습니다.
- 현재 유저가 게시물의 좋아요를 눌렀는지 상태를 확인하기 위해 매개변수로 `user_id`를 추가로 받았습니다.
